### PR TITLE
Support MAP file format version 9

### DIFF
--- a/src/gd_edit/io/map.clj
+++ b/src/gd_edit/io/map.clj
@@ -35,7 +35,7 @@
   [preamble]
 
   (when (or (not= (:magic preamble) "MAP")
-            (not= (:version preamble) 8))
+            (not (contains? #{8 9} (:version preamble))))
     (throw (Throwable. "I don't understand this MAP format!"))))
 
 (def sector-id-map


### PR DESCRIPTION
Grim Dawn updated the MAP file format from version 8 to version 9, causing "Cannot load shrine and gate names" error. This change accepts both versions since the internal structure appears unchanged.